### PR TITLE
fix: Defined item-value

### DIFF
--- a/ui/components/FilterForm.vue
+++ b/ui/components/FilterForm.vue
@@ -28,6 +28,7 @@
             :items="items"
             :search-input.sync="search"
             :filter="()=>true"
+            item-value="_id"
             DONT-cache-items
             hide-details
             hide-no-data


### PR DESCRIPTION
Since `item-value` was not being defined, objects that have identical `text` were shown as one.

Instead, by defining `item-value` as `_id` two items, for example, people, that have the same name can exist.